### PR TITLE
"ngx_ssl_generate_rsa512_key" function prevents compiling in nginx 1.0.9

### DIFF
--- a/modules/ngx_tcp_ssl_module.c
+++ b/modules/ngx_tcp_ssl_module.c
@@ -1,4 +1,3 @@
-
 #include <ngx_config.h>
 #include <ngx_core.h>
 #include <ngx_tcp.h>
@@ -335,13 +334,7 @@ ngx_tcp_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     /* a temporary 512-bit RSA key is required for export versions of MSIE */
-#if defined(nginx_version) && nginx_version >= 1001000
     SSL_CTX_set_tmp_rsa_callback(conf->ssl.ctx, ngx_ssl_rsa512_key_callback); 
-#else
-    if (ngx_ssl_generate_rsa512_key(&conf->ssl) != NGX_OK) {
-        return NGX_CONF_ERROR;
-    }
-#endif
 
     if (ngx_ssl_dhparam(cf, &conf->ssl, &conf->dhparam) != NGX_OK) {
         return NGX_CONF_ERROR;


### PR DESCRIPTION
This prevented compiling in nginx 1.0.9. "ngx_ssl_generate_rsa512_key" isn't a function anywhere, and it appears that nginx is still using the "SSL_CTX_set_tmp_rsa_callback" method.

I'm not sure if it's required in nginx 1.0.{0-8}?
