### PR TITLE
Minor documentation note

### DIFF
--- a/README
+++ b/README
@@ -461,7 +461,9 @@ Directives
 
     context: *tcp, server*
 
-    description: set the timeout value of reading from backends.
+    description: set the timeout value of reading from backends. Your timeout
+    will be the minimum of this and the "timeout" parameter, so if you want a
+    long timeout for your websockets, make sure to set both paramaters.
 
    websocket_send_timeout
     syntax: *websocket_send_timeout miliseconds*


### PR DESCRIPTION
Earlier today I was trying to set up a websocket reverse proxy, but my websockets kept closing.  I tried every combination of timeout parameters, and eventually realized that I needed to set "timeout", "websocket_read_timeout", and "websocket_send_timeout", but I didn't need to worry about any of the other timeouts, e.g. resolver_timeout, proxy_read_timeout, ssl_session_timeout, etc.

It took me quite some time to figure this out, so I figured I'd submit a 1-sentence addition to your README file to make this clearer.
