### PR TITLE
Fix links in README

### DIFF
--- a/README
+++ b/README
@@ -3,9 +3,9 @@ Name
 
 Installation
     Download the latest stable version of the release tarball of this module
-    from github (<http://github.com/yaoweibin/nginx_tcp_proxy_module>)
+    from github (http://github.com/yaoweibin/nginx_tcp_proxy_module)
 
-    Grab the nginx source code from nginx.org (<http://nginx.org/>), for
+    Grab the nginx source code from nginx.org (http://nginx.org/), for
     example, the version 1.2.1 (see nginx compatibility), and then build the
     source with this module:
 


### PR DESCRIPTION
Links have a trailing > that is breaking the links.  Removed brackets to fix.
