### PR TITLE
Fixed to match new parameters of ngx_sock_ntop

### DIFF
--- a/ngx_tcp.c
+++ b/ngx_tcp.c
@@ -473,7 +473,11 @@ ngx_tcp_add_addrs(ngx_conf_t *cf, ngx_tcp_port_t *mport,
         addrs[i].conf.ssl = addr[i].ssl;
 #endif
 
+#if defined(nginx_version) && nginx_version >= 1005003
         len = ngx_sock_ntop(addr[i].sockaddr, addr[i].socklen, buf, NGX_SOCKADDR_STRLEN, 1);
+#else
+        len = ngx_sock_ntop(addr[i].sockaddr, buf, NGX_SOCKADDR_STRLEN, 1);
+#endif
 
         p = ngx_pnalloc(cf->pool, len);
         if (p == NULL) {


### PR DESCRIPTION
Fixes to match new parameter count of nginx.

See: http://forum.nginx.org/read.php?29,240757 
