### PR TITLE
fixed the compatible problem with nginx-1.5.8

### DIFF
--- a/ngx_tcp_upstream.c
+++ b/ngx_tcp_upstream.c
@@ -242,7 +242,6 @@ ngx_tcp_upstream_init(ngx_tcp_session_t *s)
         }
 
         ctx->name = *host;
-        ctx->type = NGX_RESOLVE_A;
         ctx->handler = ngx_tcp_upstream_resolve_handler;
         ctx->data = s;
         ctx->timeout = cscf->resolver_timeout;
@@ -296,16 +295,18 @@ ngx_tcp_upstream_resolve_handler(ngx_resolver_ctx_t *ctx)
 
 #if (NGX_DEBUG)
     {
-        in_addr_t   addr;
+        u_char      text[NGX_SOCKADDR_STRLEN];
+        ngx_str_t   addr;
         ngx_uint_t  i;
 
-        for (i = 0; i < ctx->naddrs; i++) {
-            addr = ntohl(ur->addrs[i]);
+        addr.data = text;
 
-            ngx_log_debug4(NGX_LOG_DEBUG_TCP, s->connection->log, 0,
-                           "name was resolved to %ud.%ud.%ud.%ud",
-                           (addr >> 24) & 0xff, (addr >> 16) & 0xff,
-                           (addr >> 8) & 0xff, addr & 0xff);
+        for (i = 0; i < ctx->naddrs; i++) {
+            addr.len = ngx_sock_ntop(ur->addrs[i].sockaddr, ur->addrs[i].socklen,
+                                     text, NGX_SOCKADDR_STRLEN, 0);
+
+            ngx_log_debug1(NGX_LOG_DEBUG_TCP, s->connection->log, 0,
+                           "name was resolved to %V", &addr);
         }
     }
 #endif

--- a/ngx_tcp_upstream.h
+++ b/ngx_tcp_upstream.h
@@ -139,7 +139,7 @@ struct ngx_tcp_upstream_resolved_s {
     ngx_uint_t                       no_port; /* unsigned no_port:1 */
 
     ngx_uint_t                       naddrs;
-    in_addr_t                       *addrs;
+    ngx_addr_t                      *addrs;
 
     struct sockaddr                 *sockaddr;
     socklen_t                        socklen;

--- a/ngx_tcp_upstream_round_robin.c
+++ b/ngx_tcp_upstream_round_robin.c
@@ -288,8 +288,9 @@ ngx_tcp_upstream_create_round_robin_peer(ngx_tcp_session_t *s,
 {
     u_char                            *p;
     size_t                             len;
+    socklen_t                          socklen;
     ngx_uint_t                         i, n;
-    struct sockaddr_in                *sin;
+    struct sockaddr                   *sockaddr;
     ngx_tcp_upstream_rr_peers_t       *peers;
     ngx_tcp_upstream_rr_peer_data_t   *rrp;
 
@@ -328,27 +329,34 @@ ngx_tcp_upstream_create_round_robin_peer(ngx_tcp_session_t *s,
 
         for (i = 0; i < ur->naddrs; i++) {
 
-            len = NGX_INET_ADDRSTRLEN + sizeof(":65536") - 1;
+            socklen = ur->addrs[i].socklen;
 
-            p = ngx_pnalloc(s->pool, len);
+            sockaddr = ngx_palloc(s->pool, socklen);
+            if (sockaddr == NULL) {
+                return NGX_ERROR;
+            }
+
+            ngx_memcpy(sockaddr, ur->addrs[i].sockaddr, socklen);
+
+            switch (sockaddr->sa_family) {
+#if (NGX_HAVE_INET6)
+            case AF_INET6:
+                ((struct sockaddr_in6 *) sockaddr)->sin6_port = htons(ur->port);
+                break;
+#endif
+            default: /* AF_INET */
+                ((struct sockaddr_in *) sockaddr)->sin_port = htons(ur->port);
+            }
+
+            p = ngx_pnalloc(s->pool, NGX_SOCKADDR_STRLEN);
             if (p == NULL) {
                 return NGX_ERROR;
             }
 
-            len = ngx_inet_ntop(AF_INET, &ur->addrs[i], p, NGX_INET_ADDRSTRLEN);
-            len = ngx_sprintf(&p[len], ":%d", ur->port) - p;
+            len = ngx_sock_ntop(sockaddr, socklen, p, NGX_SOCKADDR_STRLEN, 1);
 
-            sin = ngx_pcalloc(s->pool, sizeof(struct sockaddr_in));
-            if (sin == NULL) {
-                return NGX_ERROR;
-            }
-
-            sin->sin_family = AF_INET;
-            sin->sin_port = htons(ur->port);
-            sin->sin_addr.s_addr = ur->addrs[i];
-
-            peers->peer[i].sockaddr = (struct sockaddr *) sin;
-            peers->peer[i].socklen = sizeof(struct sockaddr_in);
+            peers->peer[i].sockaddr = sockaddr;
+            peers->peer[i].socklen = socklen;
             peers->peer[i].name.len = len;
             peers->peer[i].name.data = p;
             peers->peer[i].weight = 1;


### PR DESCRIPTION
Hi dude,

In nginx 1.5.8, something has been changed in the "resolver" code to support resolving names into IPv6 addresses, i just follow the changes and make sure this module can be compiled with nginx 1.5.8.

Signed-off-by: paulyang y_y@neusoft.com
