### PR TITLE
added marco ngx_tcp_cycle_get_module_main_conf

### DIFF
--- a/ngx_tcp.h
+++ b/ngx_tcp.h
@@ -271,8 +271,14 @@ typedef struct {
 #define ngx_tcp_conf_get_module_srv_conf(cf, module)                        \
     ((ngx_tcp_conf_ctx_t *) cf->ctx)->srv_conf[module.ctx_index]
 
+#define ngx_tcp_cycle_get_module_main_conf(cycle, module)                   \
+    (cycle->conf_ctx[ngx_tcp_module.index] ?                                \
+        ((ngx_tcp_conf_ctx_t *) cycle->conf_ctx[ngx_tcp_module.index])      \
+            ->main_conf[module.ctx_index]:                                  \
+        NULL)
 
 extern ngx_uint_t    ngx_tcp_max_module;
 extern ngx_module_t  ngx_tcp_core_module;
+extern ngx_module_t  ngx_tcp_module;
 
 #endif /* _NGX_TCP_H_INCLUDED_ */


### PR DESCRIPTION
If developer writes a tcp module and defines ngx_module_t:init_module field,
this macro will be useful to get main conf of his tcp module from cycle.

```
struct nginx_module_s {
  ...
  ngx_int_t (*init_module)(ngx_cycle_t *cycle);
  ...
}
```

Note that http module has a similar macro (ngx_http_cycle_get_module_main_conf).
