### PR TITLE
fixed ngx_tcp_cmp_conf_addrs()

### DIFF
--- a/ngx_tcp.c
+++ b/ngx_tcp.c
@@ -571,6 +571,11 @@ ngx_tcp_cmp_conf_addrs(const void *one, const void *two)
         return 1;
     }
 
+    if (second->wildcard) {
+        /* a wildcard must be the last resort, shift it to the end */
+        return -1;
+    }
+
     if (first->bind && !second->bind) {
         /* shift explicit bind()ed addresses to the start */
         return -1;


### PR DESCRIPTION
fixed `ngx_tcp_cmp_conf_addrs()`.