### PR TITLE
make it compatible with tengine-2.2.0+

### DIFF
--- a/modules/ngx_tcp_ssl_module.c
+++ b/modules/ngx_tcp_ssl_module.c
@@ -307,7 +307,7 @@ ngx_tcp_ssl_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     cln->handler = ngx_ssl_cleanup_ctx;
     cln->data = &conf->ssl;
 
-#if defined(tengine_version)
+#if defined(tengine_version) && tengine_version < 2002000
     ngx_str_t pass_phrase_dialog              = ngx_string("builtin");
     ngx_str_t ngx_tcp_ssl_unknown_server_name = ngx_string("unknown");
 


### PR DESCRIPTION
In tengine-2.2.0+, ngx_ssl_certificate() api has been changed to the implementation of nginx official.

(new version number for TENGINE_VERSION: https://github.com/alibaba/tengine/commit/66b73ddced145f98f3e4475d39012e1138a6d8ea)